### PR TITLE
feat: decorate metadata from an AsyncAPI Document + couple of metric shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@smoya/asyncapi-adoption-metrics",
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@smoya/multi-parser": "^4.1.0"
+      },
       "devDependencies": {
         "@jest/types": "^29.0.2",
         "@swc/core": "^1.2.248",
@@ -45,6 +48,297 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asyncapi/avro-schema-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.3.tgz",
+      "integrity": "sha512-XprbDYPFJ0nc963hPCjbEmM3iu6ypKg/70EFVl0MZJCLbLw/+gBbPy95uV3Qaofm5UQgSI+aTobGhc8rMre4VA==",
+      "dependencies": {
+        "@asyncapi/parser": "^2.1.0",
+        "@types/json-schema": "^7.0.11",
+        "avsc": "^5.7.6"
+      }
+    },
+    "node_modules/@asyncapi/avro-schema-parser/node_modules/@asyncapi/parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+      "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+      "dependencies": {
+        "@asyncapi/specs": "^5.1.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/@asyncapi/avro-schema-parser/node_modules/@asyncapi/specs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/@asyncapi/avro-schema-parser/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@asyncapi/avro-schema-parser/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/@asyncapi/avro-schema-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@asyncapi/openapi-schema-parser": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-3.0.4.tgz",
+      "integrity": "sha512-nfZbL3dTpIQ3K+/V05FBpgOPi7dDWZkqZG8e7pKwtNhwZ0YLBFWTw6RpocztlBlcieFggxZqLm4BT5I1cQbK+Q==",
+      "dependencies": {
+        "@asyncapi/parser": "^2.1.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1"
+      }
+    },
+    "node_modules/@asyncapi/openapi-schema-parser/node_modules/@asyncapi/parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+      "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+      "dependencies": {
+        "@asyncapi/specs": "^5.1.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/@asyncapi/openapi-schema-parser/node_modules/@asyncapi/specs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/@asyncapi/openapi-schema-parser/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@asyncapi/openapi-schema-parser/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/@asyncapi/openapi-schema-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@asyncapi/protobuf-schema-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.0.0.tgz",
+      "integrity": "sha512-kjoLrll611K+xYC/iBUlSnZsCHbrhL999ItVHZhObUOjUB991XgonqbSAaihiiDXTYgceOLhJKAN5llkV/LOOA==",
+      "dependencies": {
+        "@asyncapi/parser": "^2.1.0",
+        "@types/protocol-buffers-schema": "^3.4.1",
+        "protocol-buffers-schema": "^3.6.0"
+      }
+    },
+    "node_modules/@asyncapi/protobuf-schema-parser/node_modules/@asyncapi/parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+      "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+      "dependencies": {
+        "@asyncapi/specs": "^5.1.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/@asyncapi/protobuf-schema-parser/node_modules/@asyncapi/specs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/@asyncapi/protobuf-schema-parser/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@asyncapi/protobuf-schema-parser/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/@asyncapi/protobuf-schema-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@asyncapi/raml-dt-schema-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/raml-dt-schema-parser/-/raml-dt-schema-parser-4.0.4.tgz",
+      "integrity": "sha512-kKam4jwYYdwqoV5zkEb3YEb8VOrN0785fc4ByazxRd+BT/RnkQTLspjTY/akdDs9DLmU4ChP73Z0vqpek6wojA==",
+      "dependencies": {
+        "@asyncapi/parser": "^2.1.0",
+        "js-yaml": "^4.1.0",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/@asyncapi/parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+      "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+      "dependencies": {
+        "@asyncapi/specs": "^5.1.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/@asyncapi/specs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@asyncapi/specs": {
+      "version": "6.0.0-next-major-spec.10",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.10.tgz",
+      "integrity": "sha512-flxUofPHdLDfbnfkLzqMPjbCj4EJTxg8q9Xxkt9hsO7BDRUDQk5C7RRBfe+HxAstl0LghX1DAQcof3+GPEXuFA==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1249,6 +1543,28 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
+      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/ternary": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.3.tgz",
+      "integrity": "sha512-qtLGzCNzPVJ3kdH6/zoLWDPjauHIKiLSBAR71Wa0+PWvGA8wODUQvRgxtpUA5YqAYL3CQ8S4qXhd/9WuWTZirg==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -1279,6 +1595,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@openapi-contrib/openapi-schema-to-json-schema": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-3.2.0.tgz",
+      "integrity": "sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "node_modules/@pkgr/utils": {
@@ -1320,6 +1644,367 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@smoya/multi-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-4.1.0.tgz",
+      "integrity": "sha512-0q4805I7ZdkKNEbNrbxmBNAdYEAH9aBYCuXiIXCbu8WC0sdRqLWmTsvg/DaNO8ZnsrGhVzy5VITf+8CKlVnGoQ==",
+      "dependencies": {
+        "@asyncapi/avro-schema-parser": "^3.0.3",
+        "@asyncapi/openapi-schema-parser": "^3.0.4",
+        "@asyncapi/protobuf-schema-parser": "^3.0.0",
+        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
+        "parserv2": "npm:@asyncapi/parser@^2.1.0",
+        "parserv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.3"
+      }
+    },
+    "node_modules/@stoplight/json": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.0.tgz",
+      "integrity": "sha512-5O0apqJ/t4sIevXCO3SBN9AHCEKKR/Zb4gaj7wYe5863jme9g02Q0n/GhM7ZCALkL+vGPTe4ZzTETP8TFtsw3g==",
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.3",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^13.6.0",
+        "jsonc-parser": "~2.2.1",
+        "lodash": "^4.17.21",
+        "safe-stable-stringify": "^1.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/json-ref-readers": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz",
+      "integrity": "sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==",
+      "dependencies": {
+        "node-fetch": "^2.6.0",
+        "tslib": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/json-ref-readers/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@stoplight/json-ref-resolver": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.6.tgz",
+      "integrity": "sha512-YNcWv3R3n3U6iQYBsFOiWSuRGE5su1tJSiX6pAPRVk7dP0L7lqCteXGzuVRQ0gMZqUl8v1P0+fAKxF6PLo9B5A==",
+      "dependencies": {
+        "@stoplight/json": "^3.21.0",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^12.3.0 || ^13.0.0",
+        "@types/urijs": "^1.19.19",
+        "dependency-graph": "~0.11.0",
+        "fast-memoize": "^2.5.2",
+        "immer": "^9.0.6",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0",
+        "urijs": "^1.19.11"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/json/node_modules/jsonc-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+      "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
+    },
+    "node_modules/@stoplight/ordered-object-literal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.4.tgz",
+      "integrity": "sha512-OF8uib1jjDs5/cCU+iOVy+GJjU3X7vk/qJIkIJFqwmlJKrrtijFmqwbu8XToXrwTYLQTP+Hebws5gtZEmk9jag==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/path": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.2.tgz",
+      "integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-core": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.18.3.tgz",
+      "integrity": "sha512-YY8x7X2SWJIhGTLPol+eFiQpWPz0D0mJdkK2i4A0QJG68KkNhypP6+JBC7/Kz3XWjqr0L/RqAd+N5cQLPOKZGQ==",
+      "dependencies": {
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-parsers": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.0",
+        "@stoplight/spectral-runtime": "^1.0.0",
+        "@stoplight/types": "~13.6.0",
+        "@types/es-aggregate-error": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "ajv": "^8.6.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "es-aggregate-error": "^1.0.7",
+        "jsonpath-plus": "7.1.0",
+        "lodash": "~4.17.21",
+        "lodash.topath": "^4.5.2",
+        "minimatch": "3.1.2",
+        "nimma": "0.2.2",
+        "pony-cause": "^1.0.0",
+        "simple-eval": "1.0.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/@stoplight/better-ajv-errors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.3.tgz",
+      "integrity": "sha512-0p9uXkuB22qGdNfy3VeEhxkU5uwvp/KrBTAbrLBURv6ilxIVwanKwjMc41lQfIVgPGcOkmLbTolfFrSsueu7zA==",
+      "dependencies": {
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/@stoplight/types": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.6.0.tgz",
+      "integrity": "sha512-dzyuzvUjv3m1wmhPfq82lCVYGcXG0xUYgqnWfCq3PCVR4BKFhjdkHrnJ+jIDoMKvXb05AZP/ObQF6+NpDo29IQ==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/jsonpath-plus": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.1.0.tgz",
+      "integrity": "sha512-gTaNRsPWO/K2KY6MrqaUFClF9kmuM6MFH5Dhg1VYDODgFbByw1yb7xu3hrViE/sz+dGOeMWgCzwUwQtAnCTE9g==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@stoplight/spectral-formats": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.5.0.tgz",
+      "integrity": "sha512-VskkdU3qBSvI1dfJ79ysjvTssfNlbA6wrf/XkXK6iTyjfIVqOAWVtjypTb2U95tN/X8IjIBBhNWtZ4tNVZilrA==",
+      "dependencies": {
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.8.0",
+        "@types/json-schema": "^7.0.7",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@stoplight/spectral-functions": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.7.2.tgz",
+      "integrity": "sha512-f+61/FtIkQeIo+a269CeaeqjpyRsgDyIk6DGr7iS4hyuk1PPk7Uf6MNRDs9FEIBh7CpdEJ+HSHbMLwgpymWTIw==",
+      "dependencies": {
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.1",
+        "@stoplight/spectral-core": "^1.7.0",
+        "@stoplight/spectral-formats": "^1.0.0",
+        "@stoplight/spectral-runtime": "^1.1.0",
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "lodash": "~4.17.21",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@stoplight/spectral-functions/node_modules/@stoplight/better-ajv-errors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.3.tgz",
+      "integrity": "sha512-0p9uXkuB22qGdNfy3VeEhxkU5uwvp/KrBTAbrLBURv6ilxIVwanKwjMc41lQfIVgPGcOkmLbTolfFrSsueu7zA==",
+      "dependencies": {
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-functions/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@stoplight/spectral-functions/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stoplight/spectral-functions/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/@stoplight/spectral-functions/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@stoplight/spectral-parsers": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-parsers/-/spectral-parsers-1.0.3.tgz",
+      "integrity": "sha512-J0KW5Rh5cHWnJQ3yN+cr/ijNFVirPSR0pkQbdrNX30VboEl083UEDrQ3yov9kjLVIWEk9t9kKE7Eo3QT/k4JLA==",
+      "dependencies": {
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/types": "^13.6.0",
+        "@stoplight/yaml": "~4.2.3",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-ref-resolver": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ref-resolver/-/spectral-ref-resolver-1.0.4.tgz",
+      "integrity": "sha512-5baQIYL0NJTSVy8v6RxOR4U51xOUYM8wJri1YvlAT6bPN8m0EIxMwfVYi0xUZEMVeHcWx869nIkoqyWmOutF2A==",
+      "dependencies": {
+        "@stoplight/json-ref-readers": "1.2.2",
+        "@stoplight/json-ref-resolver": "~3.1.6",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "dependency-graph": "0.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@stoplight/spectral-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-runtime/-/spectral-runtime-1.1.2.tgz",
+      "integrity": "sha512-fr5zRceXI+hrl82yAVoME+4GvJie8v3wmOe9tU+ZLRRNonizthy8qDi0Z/z4olE+vGreSDcuDOZ7JjRxFW5kTw==",
+      "dependencies": {
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^12.3.0",
+        "abort-controller": "^3.0.0",
+        "lodash": "^4.17.21",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@stoplight/spectral-runtime/node_modules/@stoplight/types": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.5.0.tgz",
+      "integrity": "sha512-dwqYcDrGmEyUv5TWrDam5TGOxU72ufyQ7hnOIIDdmW5ezOwZaBFoR5XQ9AsH49w7wgvOqB2Bmo799pJPWnpCbg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/types": {
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.20.0.tgz",
+      "integrity": "sha512-2FNTv05If7ib79VPDA/r9eUet76jewXFH2y2K5vuge6SXbRHtWBhcaRmu+6QpF4/WRNoJj5XYRSwLGXDxysBGA==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/yaml": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.2.3.tgz",
+      "integrity": "sha512-Mx01wjRAR9C7yLMUyYFTfbUf5DimEpHMkRDQ1PKLe9dfNILbgdxyrncsOXM3vCpsQ1Hfj4bPiGl+u4u6e9Akqw==",
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.1",
+        "@stoplight/types": "^13.0.0",
+        "@stoplight/yaml-ast-parser": "0.0.48",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.8"
+      }
+    },
+    "node_modules/@stoplight/yaml-ast-parser": {
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz",
+      "integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg=="
     },
     "node_modules/@swc/core": {
       "version": "1.3.78",
@@ -1441,6 +2126,14 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/es-aggregate-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/es-aggregate-error/-/es-aggregate-error-1.0.4.tgz",
+      "integrity": "sha512-95tL6tLR8P3Utx4SxXUEc0e+k2B9VhtBozhgxKGpv30ylIuxGxf080d7mYZ08sH5UjpDv/Nd6F80tH1p+KuPIg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.2",
       "dev": true,
@@ -1507,7 +2200,6 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -1517,8 +2209,15 @@
     },
     "node_modules/@types/node": {
       "version": "20.5.0",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/protocol-buffers-schema": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/protocol-buffers-schema/-/protocol-buffers-schema-3.4.2.tgz",
+      "integrity": "sha512-GaQpfsfFk4wGU3//d7uCGy9zy6B8QBEyWYd6+maZH+S6m861QrFvLWS5RyHj4UfIiON9tmqCz9C+oNpebDgGIw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -1529,6 +2228,11 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/urijs": {
+      "version": "1.19.22",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.22.tgz",
+      "integrity": "sha512-qnYBwfN7O/+i6E1Kr8JaCKsrCLpRCiQ1XxkSxNIYuJ/5Aagt0+HlMX78DJMUrNzDULMz0eu2gcprlxJaDtACOw=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -1881,6 +2585,17 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.10.0",
       "dev": true,
@@ -1923,6 +2638,42 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -2018,7 +2769,6 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -2031,7 +2781,6 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -2121,7 +2870,6 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
@@ -2143,6 +2891,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/astring": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
+      "integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/autolinker": {
       "version": "0.28.1",
       "dev": true,
@@ -2153,13 +2909,20 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/avsc": {
+      "version": "5.7.7",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.7.tgz",
+      "integrity": "sha512-9cYNccliXZDByFsFliVwk5GvTq058Fj513CiR4E60ndDwmuXzTJEp/Bp8FyuRmGyYupLjHLs+JA9/CBoVS4/NQ==",
+      "engines": {
+        "node": ">=0.11"
       }
     },
     "node_modules/axe-core": {
@@ -2285,7 +3048,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2294,7 +3056,6 @@
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/braces": {
@@ -2379,7 +3140,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -2490,7 +3250,6 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -2538,7 +3297,6 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -2792,6 +3550,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "dev": true,
@@ -2804,10 +3575,11 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -2816,6 +3588,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/dequal": {
@@ -2923,7 +3703,6 @@
     },
     "node_modules/es-abstract": {
       "version": "1.22.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
@@ -2973,6 +3752,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-aggregate-error": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.11.tgz",
+      "integrity": "sha512-DCiZiNlMlbvofET/cE55My387NiLvuGToBEZDdK9U2G3svDCjL8WOgO5Il6lO83nQ8qmag/R9nArdpaFQ/m3lA==",
+      "dependencies": {
+        "define-data-property": "^1.1.0",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.2.1",
+        "globalthis": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "set-function-name": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.3.0",
       "dev": true,
@@ -2981,7 +3781,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3",
@@ -3002,7 +3801,6 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -3633,7 +4431,6 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -3695,6 +4492,14 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -3831,7 +4636,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -3867,13 +4671,17 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -3951,7 +4759,6 @@
     },
     "node_modules/for-each": {
       "version": "0.3.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
@@ -3984,12 +4791,10 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -4006,7 +4811,6 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4030,7 +4834,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -4063,7 +4866,6 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -4128,7 +4930,6 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.1.3"
@@ -4161,7 +4962,6 @@
     },
     "node_modules/gopd": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
@@ -4227,7 +5027,6 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -4238,7 +5037,6 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4254,7 +5052,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.1"
@@ -4265,7 +5062,6 @@
     },
     "node_modules/has-proto": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4276,7 +5072,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4287,7 +5082,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -4318,6 +5112,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -4377,7 +5180,6 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.0",
@@ -4390,7 +5192,6 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -4408,7 +5209,6 @@
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -4419,7 +5219,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -4439,7 +5238,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4461,7 +5259,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -4549,7 +5346,6 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4571,7 +5367,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -4612,7 +5407,6 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -4627,7 +5421,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -4649,7 +5442,6 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -4663,7 +5455,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -4677,7 +5468,6 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.12",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.11"
@@ -4691,7 +5481,6 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -5648,13 +6437,20 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.8.tgz",
+      "integrity": "sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==",
+      "engines": {
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/jsesc": {
@@ -5673,9 +6469,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-migrate": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-0.2.0.tgz",
+      "integrity": "sha512-dq4/oHWmtw/+0ytnXsDqVn+VsVweTEmzm5jLgguPn9BjSzn6/q58ZiZx3BHiQyJs612f0T5Z+MrUEUUY5DHsRg==",
+      "dependencies": {
+        "ajv": "^5.0.0"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw=="
+    },
+    "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA=="
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -5698,6 +6522,22 @@
       "version": "3.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -5758,7 +6598,6 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5818,6 +6657,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
       "dev": true,
@@ -5859,6 +6703,11 @@
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "node_modules/lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg=="
     },
     "node_modules/lodash.upperfirst": {
       "version": "4.3.1",
@@ -5994,7 +6843,6 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6055,6 +6903,52 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/nimma": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.2.tgz",
+      "integrity": "sha512-V52MLl7BU+tH2Np9tDrIXK8bql3MVUadnMIl/0/oZSGC9keuro0O9UUv9QKp0aMvtN8HRew4G7byY7H4eWsxaQ==",
+      "dependencies": {
+        "@jsep-plugin/regex": "^1.0.1",
+        "@jsep-plugin/ternary": "^1.0.2",
+        "astring": "^1.8.1",
+        "jsep": "^1.2.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
+      "optionalDependencies": {
+        "jsonpath-plus": "^6.0.1",
+        "lodash.topath": "^4.5.2"
+      }
+    },
+    "node_modules/nimma/node_modules/jsonpath-plus": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
+      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "dev": true,
@@ -6086,7 +6980,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6094,7 +6987,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6102,7 +6994,6 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6311,6 +7202,120 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parserv2": {
+      "name": "@asyncapi/parser",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+      "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+      "dependencies": {
+        "@asyncapi/specs": "^5.1.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/parserv2/node_modules/@asyncapi/specs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/parserv2/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/parserv2/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/parserv2/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/parserv3": {
+      "name": "@asyncapi/parser",
+      "version": "3.0.0-next-major-spec.7",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.7.tgz",
+      "integrity": "sha512-iCVCd66h6NXrIVu7aK5RwGuJ4g1j+qD88xxejUwczbpGbhJkuZUzF5jReWNNAizETJttnAwW0rBKjZF4HVqOiQ==",
+      "dependencies": {
+        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/parserv3/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/parserv3/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/parserv3/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -6431,6 +7436,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/pony-cause": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-1.1.1.tgz",
+      "integrity": "sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -6505,6 +7518,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+    },
     "node_modules/pure-rand": {
       "version": "6.0.2",
       "dev": true,
@@ -6538,6 +7556,49 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/ramldt2jsonschema": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ramldt2jsonschema/-/ramldt2jsonschema-1.2.3.tgz",
+      "integrity": "sha512-+wLDAV2NNv9NkfEUOYStaDu/6RYgYXeC1zLtXE+dMU/jDfjpN4iJnBGycDwFTFaIQGosOQhxph7fEX6Mpwxdug==",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^0.2.0",
+        "webapi-parser": "^0.5.0"
+      },
+      "bin": {
+        "dt2js": "bin/dt2js.js",
+        "js2dt": "bin/js2dt.js"
+      }
+    },
+    "node_modules/ramldt2jsonschema/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/ramldt2jsonschema/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ramldt2jsonschema/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/randomatic": {
       "version": "3.1.1",
@@ -6624,7 +7685,6 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6681,6 +7741,14 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6797,7 +7865,6 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6814,7 +7881,6 @@
     },
     "node_modules/safe-array-concat/node_modules/isarray": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-buffer": {
@@ -6847,7 +7913,6 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6857,6 +7922,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -6915,6 +7985,19 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/set-function-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/set-getter": {
       "version": "0.1.1",
       "dev": true,
@@ -6947,7 +8030,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -6962,6 +8044,17 @@
       "version": "3.0.7",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-eval": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.0.tgz",
+      "integrity": "sha512-kpKJR+bqTscgC0xuAl2xHN6bB12lHjC2DCUfqjAx19bQyO3R2EVLOurm3H9AUltv/uFVcSCVNc6faegR+8NYLw==",
+      "dependencies": {
+        "jsep": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -6995,7 +8088,6 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
@@ -7049,7 +8141,6 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7065,7 +8156,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7078,7 +8168,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7375,6 +8464,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts-api-utils": {
       "version": "1.0.1",
       "dev": true,
@@ -7486,7 +8580,6 @@
     },
     "node_modules/tslib": {
       "version": "2.6.1",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -7540,7 +8633,6 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7553,7 +8645,6 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7570,7 +8661,6 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
@@ -7588,7 +8678,6 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7618,7 +8707,6 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7669,7 +8757,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -7677,16 +8764,28 @@
     },
     "node_modules/uri-js/node_modules/punycode": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -7731,6 +8830,35 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/webapi-parser": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webapi-parser/-/webapi-parser-0.5.0.tgz",
+      "integrity": "sha512-fPt6XuMqLSvBz8exwX4QE1UT+pROLHa00EMDCdO0ybICduwQ1V4f7AWX4pNOpCp+x+0FjczEsOxtQU0d8L3QKw==",
+      "dependencies": {
+        "ajv": "6.5.2"
+      }
+    },
+    "node_modules/webapi-parser/node_modules/ajv": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.1"
+      }
+    },
+    "node_modules/webapi-parser/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
       "version": "5.88.2",
@@ -7797,6 +8925,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -7813,7 +8950,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -7828,7 +8964,6 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
@@ -7954,6 +9089,281 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@asyncapi/avro-schema-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.3.tgz",
+      "integrity": "sha512-XprbDYPFJ0nc963hPCjbEmM3iu6ypKg/70EFVl0MZJCLbLw/+gBbPy95uV3Qaofm5UQgSI+aTobGhc8rMre4VA==",
+      "requires": {
+        "@asyncapi/parser": "^2.1.0",
+        "@types/json-schema": "^7.0.11",
+        "avsc": "^5.7.6"
+      },
+      "dependencies": {
+        "@asyncapi/parser": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+          "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+          "requires": {
+            "@asyncapi/specs": "^5.1.0",
+            "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+            "@stoplight/json-ref-resolver": "^3.1.5",
+            "@stoplight/spectral-core": "^1.16.1",
+            "@stoplight/spectral-functions": "^1.7.2",
+            "@stoplight/spectral-parsers": "^1.0.2",
+            "@types/json-schema": "^7.0.11",
+            "@types/urijs": "^1.19.19",
+            "ajv": "^8.11.0",
+            "ajv-errors": "^3.0.0",
+            "ajv-formats": "^2.1.1",
+            "avsc": "^5.7.5",
+            "js-yaml": "^4.1.0",
+            "jsonpath-plus": "^7.2.0",
+            "node-fetch": "2.6.7",
+            "ramldt2jsonschema": "^1.2.3",
+            "webapi-parser": "^0.5.0"
+          }
+        },
+        "@asyncapi/specs": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+          "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+          "requires": {
+            "@types/json-schema": "^7.0.11"
+          }
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "@asyncapi/openapi-schema-parser": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-3.0.4.tgz",
+      "integrity": "sha512-nfZbL3dTpIQ3K+/V05FBpgOPi7dDWZkqZG8e7pKwtNhwZ0YLBFWTw6RpocztlBlcieFggxZqLm4BT5I1cQbK+Q==",
+      "requires": {
+        "@asyncapi/parser": "^2.1.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1"
+      },
+      "dependencies": {
+        "@asyncapi/parser": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+          "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+          "requires": {
+            "@asyncapi/specs": "^5.1.0",
+            "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+            "@stoplight/json-ref-resolver": "^3.1.5",
+            "@stoplight/spectral-core": "^1.16.1",
+            "@stoplight/spectral-functions": "^1.7.2",
+            "@stoplight/spectral-parsers": "^1.0.2",
+            "@types/json-schema": "^7.0.11",
+            "@types/urijs": "^1.19.19",
+            "ajv": "^8.11.0",
+            "ajv-errors": "^3.0.0",
+            "ajv-formats": "^2.1.1",
+            "avsc": "^5.7.5",
+            "js-yaml": "^4.1.0",
+            "jsonpath-plus": "^7.2.0",
+            "node-fetch": "2.6.7",
+            "ramldt2jsonschema": "^1.2.3",
+            "webapi-parser": "^0.5.0"
+          }
+        },
+        "@asyncapi/specs": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+          "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+          "requires": {
+            "@types/json-schema": "^7.0.11"
+          }
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "@asyncapi/protobuf-schema-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.0.0.tgz",
+      "integrity": "sha512-kjoLrll611K+xYC/iBUlSnZsCHbrhL999ItVHZhObUOjUB991XgonqbSAaihiiDXTYgceOLhJKAN5llkV/LOOA==",
+      "requires": {
+        "@asyncapi/parser": "^2.1.0",
+        "@types/protocol-buffers-schema": "^3.4.1",
+        "protocol-buffers-schema": "^3.6.0"
+      },
+      "dependencies": {
+        "@asyncapi/parser": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+          "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+          "requires": {
+            "@asyncapi/specs": "^5.1.0",
+            "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+            "@stoplight/json-ref-resolver": "^3.1.5",
+            "@stoplight/spectral-core": "^1.16.1",
+            "@stoplight/spectral-functions": "^1.7.2",
+            "@stoplight/spectral-parsers": "^1.0.2",
+            "@types/json-schema": "^7.0.11",
+            "@types/urijs": "^1.19.19",
+            "ajv": "^8.11.0",
+            "ajv-errors": "^3.0.0",
+            "ajv-formats": "^2.1.1",
+            "avsc": "^5.7.5",
+            "js-yaml": "^4.1.0",
+            "jsonpath-plus": "^7.2.0",
+            "node-fetch": "2.6.7",
+            "ramldt2jsonschema": "^1.2.3",
+            "webapi-parser": "^0.5.0"
+          }
+        },
+        "@asyncapi/specs": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+          "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+          "requires": {
+            "@types/json-schema": "^7.0.11"
+          }
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "@asyncapi/raml-dt-schema-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/raml-dt-schema-parser/-/raml-dt-schema-parser-4.0.4.tgz",
+      "integrity": "sha512-kKam4jwYYdwqoV5zkEb3YEb8VOrN0785fc4ByazxRd+BT/RnkQTLspjTY/akdDs9DLmU4ChP73Z0vqpek6wojA==",
+      "requires": {
+        "@asyncapi/parser": "^2.1.0",
+        "js-yaml": "^4.1.0",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      },
+      "dependencies": {
+        "@asyncapi/parser": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+          "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+          "requires": {
+            "@asyncapi/specs": "^5.1.0",
+            "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+            "@stoplight/json-ref-resolver": "^3.1.5",
+            "@stoplight/spectral-core": "^1.16.1",
+            "@stoplight/spectral-functions": "^1.7.2",
+            "@stoplight/spectral-parsers": "^1.0.2",
+            "@types/json-schema": "^7.0.11",
+            "@types/urijs": "^1.19.19",
+            "ajv": "^8.11.0",
+            "ajv-errors": "^3.0.0",
+            "ajv-formats": "^2.1.1",
+            "avsc": "^5.7.5",
+            "js-yaml": "^4.1.0",
+            "jsonpath-plus": "^7.2.0",
+            "node-fetch": "2.6.7",
+            "ramldt2jsonschema": "^1.2.3",
+            "webapi-parser": "^0.5.0"
+          }
+        },
+        "@asyncapi/specs": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+          "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+          "requires": {
+            "@types/json-schema": "^7.0.11"
+          }
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "@asyncapi/specs": {
+      "version": "6.0.0-next-major-spec.10",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.10.tgz",
+      "integrity": "sha512-flxUofPHdLDfbnfkLzqMPjbCj4EJTxg8q9Xxkt9hsO7BDRUDQk5C7RRBfe+HxAstl0LghX1DAQcof3+GPEXuFA==",
+      "requires": {
+        "@types/json-schema": "^7.0.11"
       }
     },
     "@babel/code-frame": {
@@ -8767,6 +10177,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@jsep-plugin/regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
+      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "requires": {}
+    },
+    "@jsep-plugin/ternary": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.3.tgz",
+      "integrity": "sha512-qtLGzCNzPVJ3kdH6/zoLWDPjauHIKiLSBAR71Wa0+PWvGA8wODUQvRgxtpUA5YqAYL3CQ8S4qXhd/9WuWTZirg==",
+      "requires": {}
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -8785,6 +10207,14 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@openapi-contrib/openapi-schema-to-json-schema": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-3.2.0.tgz",
+      "integrity": "sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "@pkgr/utils": {
@@ -8816,6 +10246,298 @@
       "requires": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "@smoya/multi-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-4.1.0.tgz",
+      "integrity": "sha512-0q4805I7ZdkKNEbNrbxmBNAdYEAH9aBYCuXiIXCbu8WC0sdRqLWmTsvg/DaNO8ZnsrGhVzy5VITf+8CKlVnGoQ==",
+      "requires": {
+        "@asyncapi/avro-schema-parser": "^3.0.3",
+        "@asyncapi/openapi-schema-parser": "^3.0.4",
+        "@asyncapi/protobuf-schema-parser": "^3.0.0",
+        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
+        "parserv2": "npm:@asyncapi/parser@^2.1.0",
+        "parserv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.3"
+      }
+    },
+    "@stoplight/json": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.0.tgz",
+      "integrity": "sha512-5O0apqJ/t4sIevXCO3SBN9AHCEKKR/Zb4gaj7wYe5863jme9g02Q0n/GhM7ZCALkL+vGPTe4ZzTETP8TFtsw3g==",
+      "requires": {
+        "@stoplight/ordered-object-literal": "^1.0.3",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^13.6.0",
+        "jsonc-parser": "~2.2.1",
+        "lodash": "^4.17.21",
+        "safe-stable-stringify": "^1.1"
+      },
+      "dependencies": {
+        "jsonc-parser": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+          "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
+        }
+      }
+    },
+    "@stoplight/json-ref-readers": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz",
+      "integrity": "sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==",
+      "requires": {
+        "node-fetch": "^2.6.0",
+        "tslib": "^1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@stoplight/json-ref-resolver": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.6.tgz",
+      "integrity": "sha512-YNcWv3R3n3U6iQYBsFOiWSuRGE5su1tJSiX6pAPRVk7dP0L7lqCteXGzuVRQ0gMZqUl8v1P0+fAKxF6PLo9B5A==",
+      "requires": {
+        "@stoplight/json": "^3.21.0",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^12.3.0 || ^13.0.0",
+        "@types/urijs": "^1.19.19",
+        "dependency-graph": "~0.11.0",
+        "fast-memoize": "^2.5.2",
+        "immer": "^9.0.6",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0",
+        "urijs": "^1.19.11"
+      }
+    },
+    "@stoplight/ordered-object-literal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.4.tgz",
+      "integrity": "sha512-OF8uib1jjDs5/cCU+iOVy+GJjU3X7vk/qJIkIJFqwmlJKrrtijFmqwbu8XToXrwTYLQTP+Hebws5gtZEmk9jag=="
+    },
+    "@stoplight/path": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.2.tgz",
+      "integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ=="
+    },
+    "@stoplight/spectral-core": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.18.3.tgz",
+      "integrity": "sha512-YY8x7X2SWJIhGTLPol+eFiQpWPz0D0mJdkK2i4A0QJG68KkNhypP6+JBC7/Kz3XWjqr0L/RqAd+N5cQLPOKZGQ==",
+      "requires": {
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-parsers": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.0",
+        "@stoplight/spectral-runtime": "^1.0.0",
+        "@stoplight/types": "~13.6.0",
+        "@types/es-aggregate-error": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "ajv": "^8.6.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "es-aggregate-error": "^1.0.7",
+        "jsonpath-plus": "7.1.0",
+        "lodash": "~4.17.21",
+        "lodash.topath": "^4.5.2",
+        "minimatch": "3.1.2",
+        "nimma": "0.2.2",
+        "pony-cause": "^1.0.0",
+        "simple-eval": "1.0.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@stoplight/better-ajv-errors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.3.tgz",
+          "integrity": "sha512-0p9uXkuB22qGdNfy3VeEhxkU5uwvp/KrBTAbrLBURv6ilxIVwanKwjMc41lQfIVgPGcOkmLbTolfFrSsueu7zA==",
+          "requires": {
+            "jsonpointer": "^5.0.0",
+            "leven": "^3.1.0"
+          }
+        },
+        "@stoplight/types": {
+          "version": "13.6.0",
+          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.6.0.tgz",
+          "integrity": "sha512-dzyuzvUjv3m1wmhPfq82lCVYGcXG0xUYgqnWfCq3PCVR4BKFhjdkHrnJ+jIDoMKvXb05AZP/ObQF6+NpDo29IQ==",
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "utility-types": "^3.10.0"
+          }
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "jsonpath-plus": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.1.0.tgz",
+          "integrity": "sha512-gTaNRsPWO/K2KY6MrqaUFClF9kmuM6MFH5Dhg1VYDODgFbByw1yb7xu3hrViE/sz+dGOeMWgCzwUwQtAnCTE9g=="
+        }
+      }
+    },
+    "@stoplight/spectral-formats": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.5.0.tgz",
+      "integrity": "sha512-VskkdU3qBSvI1dfJ79ysjvTssfNlbA6wrf/XkXK6iTyjfIVqOAWVtjypTb2U95tN/X8IjIBBhNWtZ4tNVZilrA==",
+      "requires": {
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.8.0",
+        "@types/json-schema": "^7.0.7",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@stoplight/spectral-functions": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.7.2.tgz",
+      "integrity": "sha512-f+61/FtIkQeIo+a269CeaeqjpyRsgDyIk6DGr7iS4hyuk1PPk7Uf6MNRDs9FEIBh7CpdEJ+HSHbMLwgpymWTIw==",
+      "requires": {
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.1",
+        "@stoplight/spectral-core": "^1.7.0",
+        "@stoplight/spectral-formats": "^1.0.0",
+        "@stoplight/spectral-runtime": "^1.1.0",
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "lodash": "~4.17.21",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@stoplight/better-ajv-errors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.3.tgz",
+          "integrity": "sha512-0p9uXkuB22qGdNfy3VeEhxkU5uwvp/KrBTAbrLBURv6ilxIVwanKwjMc41lQfIVgPGcOkmLbTolfFrSsueu7zA==",
+          "requires": {
+            "jsonpointer": "^5.0.0",
+            "leven": "^3.1.0"
+          }
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-draft-04": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+          "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+          "requires": {}
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "@stoplight/spectral-parsers": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-parsers/-/spectral-parsers-1.0.3.tgz",
+      "integrity": "sha512-J0KW5Rh5cHWnJQ3yN+cr/ijNFVirPSR0pkQbdrNX30VboEl083UEDrQ3yov9kjLVIWEk9t9kKE7Eo3QT/k4JLA==",
+      "requires": {
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/types": "^13.6.0",
+        "@stoplight/yaml": "~4.2.3",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@stoplight/spectral-ref-resolver": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ref-resolver/-/spectral-ref-resolver-1.0.4.tgz",
+      "integrity": "sha512-5baQIYL0NJTSVy8v6RxOR4U51xOUYM8wJri1YvlAT6bPN8m0EIxMwfVYi0xUZEMVeHcWx869nIkoqyWmOutF2A==",
+      "requires": {
+        "@stoplight/json-ref-readers": "1.2.2",
+        "@stoplight/json-ref-resolver": "~3.1.6",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "dependency-graph": "0.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@stoplight/spectral-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-runtime/-/spectral-runtime-1.1.2.tgz",
+      "integrity": "sha512-fr5zRceXI+hrl82yAVoME+4GvJie8v3wmOe9tU+ZLRRNonizthy8qDi0Z/z4olE+vGreSDcuDOZ7JjRxFW5kTw==",
+      "requires": {
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^12.3.0",
+        "abort-controller": "^3.0.0",
+        "lodash": "^4.17.21",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@stoplight/types": {
+          "version": "12.5.0",
+          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.5.0.tgz",
+          "integrity": "sha512-dwqYcDrGmEyUv5TWrDam5TGOxU72ufyQ7hnOIIDdmW5ezOwZaBFoR5XQ9AsH49w7wgvOqB2Bmo799pJPWnpCbg==",
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "utility-types": "^3.10.0"
+          }
+        }
+      }
+    },
+    "@stoplight/types": {
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.20.0.tgz",
+      "integrity": "sha512-2FNTv05If7ib79VPDA/r9eUet76jewXFH2y2K5vuge6SXbRHtWBhcaRmu+6QpF4/WRNoJj5XYRSwLGXDxysBGA==",
+      "requires": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "@stoplight/yaml": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.2.3.tgz",
+      "integrity": "sha512-Mx01wjRAR9C7yLMUyYFTfbUf5DimEpHMkRDQ1PKLe9dfNILbgdxyrncsOXM3vCpsQ1Hfj4bPiGl+u4u6e9Akqw==",
+      "requires": {
+        "@stoplight/ordered-object-literal": "^1.0.1",
+        "@stoplight/types": "^13.0.0",
+        "@stoplight/yaml-ast-parser": "0.0.48",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@stoplight/yaml-ast-parser": {
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz",
+      "integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg=="
     },
     "@swc/core": {
       "version": "1.3.78",
@@ -8895,6 +10617,14 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "@types/es-aggregate-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/es-aggregate-error/-/es-aggregate-error-1.0.4.tgz",
+      "integrity": "sha512-95tL6tLR8P3Utx4SxXUEc0e+k2B9VhtBozhgxKGpv30ylIuxGxf080d7mYZ08sH5UjpDv/Nd6F80tH1p+KuPIg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint": {
       "version": "8.44.2",
       "dev": true,
@@ -8952,16 +10682,22 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.12",
-      "dev": true
+      "version": "7.0.12"
     },
     "@types/json5": {
       "version": "0.0.29",
       "dev": true
     },
     "@types/node": {
-      "version": "20.5.0",
-      "dev": true
+      "version": "20.5.0"
+    },
+    "@types/protocol-buffers-schema": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/protocol-buffers-schema/-/protocol-buffers-schema-3.4.2.tgz",
+      "integrity": "sha512-GaQpfsfFk4wGU3//d7uCGy9zy6B8QBEyWYd6+maZH+S6m861QrFvLWS5RyHj4UfIiON9tmqCz9C+oNpebDgGIw==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/semver": {
       "version": "7.5.0",
@@ -8970,6 +10706,11 @@
     "@types/stack-utils": {
       "version": "2.0.1",
       "dev": true
+    },
+    "@types/urijs": {
+      "version": "1.19.22",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.22.tgz",
+      "integrity": "sha512-qnYBwfN7O/+i6E1Kr8JaCKsrCLpRCiQ1XxkSxNIYuJ/5Aagt0+HlMX78DJMUrNzDULMz0eu2gcprlxJaDtACOw=="
     },
     "@types/yargs": {
       "version": "17.0.24",
@@ -9206,6 +10947,14 @@
       "dev": true,
       "peer": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "8.10.0",
       "dev": true
@@ -9229,6 +10978,32 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
     "ajv-keywords": {
@@ -9285,8 +11060,7 @@
       "dev": true
     },
     "argparse": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "aria-query": {
       "version": "5.3.0",
@@ -9297,7 +11071,6 @@
     },
     "array-buffer-byte-length": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "is-array-buffer": "^3.0.1"
@@ -9351,7 +11124,6 @@
     },
     "arraybuffer.prototype.slice": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.2",
@@ -9365,6 +11137,11 @@
       "version": "0.0.7",
       "dev": true
     },
+    "astring": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
+      "integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg=="
+    },
     "autolinker": {
       "version": "0.28.1",
       "dev": true,
@@ -9373,8 +11150,12 @@
       }
     },
     "available-typed-arrays": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.0.5"
+    },
+    "avsc": {
+      "version": "5.7.7",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.7.tgz",
+      "integrity": "sha512-9cYNccliXZDByFsFliVwk5GvTq058Fj513CiR4E60ndDwmuXzTJEp/Bp8FyuRmGyYupLjHLs+JA9/CBoVS4/NQ=="
     },
     "axe-core": {
       "version": "4.7.2",
@@ -9460,15 +11241,13 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       },
       "dependencies": {
         "balanced-match": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         }
       }
     },
@@ -9518,7 +11297,6 @@
     },
     "call-bind": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -9571,8 +11349,7 @@
       }
     },
     "co": {
-      "version": "4.6.0",
-      "dev": true
+      "version": "4.6.0"
     },
     "coffee-script": {
       "version": "1.12.7",
@@ -9599,8 +11376,7 @@
       "peer": true
     },
     "concat-map": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -9742,17 +11518,34 @@
         "untildify": "^4.0.0"
       }
     },
+    "define-data-property": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "requires": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      }
+    },
     "define-lazy-prop": {
       "version": "3.0.0",
       "dev": true
     },
     "define-properties": {
-      "version": "1.2.0",
-      "dev": true,
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "requires": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg=="
     },
     "dequal": {
       "version": "2.0.3",
@@ -9817,7 +11610,6 @@
     },
     "es-abstract": {
       "version": "1.22.1",
-      "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
         "arraybuffer.prototype.slice": "^1.0.1",
@@ -9860,6 +11652,21 @@
         "which-typed-array": "^1.1.10"
       }
     },
+    "es-aggregate-error": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.11.tgz",
+      "integrity": "sha512-DCiZiNlMlbvofET/cE55My387NiLvuGToBEZDdK9U2G3svDCjL8WOgO5Il6lO83nQ8qmag/R9nArdpaFQ/m3lA==",
+      "requires": {
+        "define-data-property": "^1.1.0",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.2.1",
+        "globalthis": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "set-function-name": "^2.0.1"
+      }
+    },
     "es-module-lexer": {
       "version": "1.3.0",
       "dev": true,
@@ -9867,7 +11674,6 @@
     },
     "es-set-tostringtag": {
       "version": "2.0.1",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.3",
         "has": "^1.0.3",
@@ -9883,7 +11689,6 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -10261,8 +12066,7 @@
       }
     },
     "esprima": {
-      "version": "4.0.1",
-      "dev": true
+      "version": "4.0.1"
     },
     "esquery": {
       "version": "1.5.0",
@@ -10297,6 +12101,11 @@
     "esutils": {
       "version": "2.0.3",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "execa": {
       "version": "5.1.1",
@@ -10387,8 +12196,7 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true
+      "version": "3.1.3"
     },
     "fast-diff": {
       "version": "1.3.0",
@@ -10415,12 +12223,16 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "dev": true
+    },
+    "fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "fastq": {
       "version": "1.15.0",
@@ -10476,7 +12288,6 @@
     },
     "for-each": {
       "version": "0.3.3",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -10495,12 +12306,10 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "function.prototype.name": {
       "version": "1.1.5",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -10509,8 +12318,7 @@
       }
     },
     "functions-have-names": {
-      "version": "1.2.3",
-      "dev": true
+      "version": "1.2.3"
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -10522,7 +12330,6 @@
     },
     "get-intrinsic": {
       "version": "1.2.1",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -10540,7 +12347,6 @@
     },
     "get-symbol-description": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -10579,7 +12385,6 @@
     },
     "globalthis": {
       "version": "1.0.3",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3"
       }
@@ -10598,7 +12403,6 @@
     },
     "gopd": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.3"
       }
@@ -10650,14 +12454,12 @@
     },
     "has": {
       "version": "1.0.3",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
     },
     "has-bigints": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "has-flag": {
       "version": "4.0.0",
@@ -10665,22 +12467,18 @@
     },
     "has-property-descriptors": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
     },
     "has-proto": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "has-tostringtag": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -10696,6 +12494,11 @@
     "ignore": {
       "version": "5.2.4",
       "dev": true
+    },
+    "immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -10731,7 +12534,6 @@
     },
     "internal-slot": {
       "version": "1.0.5",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
@@ -10740,7 +12542,6 @@
     },
     "is-array-buffer": {
       "version": "3.0.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.0",
@@ -10753,14 +12554,12 @@
     },
     "is-bigint": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
     },
     "is-boolean-object": {
       "version": "1.1.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -10771,8 +12570,7 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.7",
-      "dev": true
+      "version": "1.2.7"
     },
     "is-core-module": {
       "version": "2.13.0",
@@ -10783,7 +12581,6 @@
     },
     "is-date-object": {
       "version": "1.0.5",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -10823,8 +12620,7 @@
       }
     },
     "is-negative-zero": {
-      "version": "2.0.2",
-      "dev": true
+      "version": "2.0.2"
     },
     "is-number": {
       "version": "2.1.0",
@@ -10835,7 +12631,6 @@
     },
     "is-number-object": {
       "version": "1.0.7",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -10859,7 +12654,6 @@
     },
     "is-regex": {
       "version": "1.1.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -10867,7 +12661,6 @@
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -10878,28 +12671,24 @@
     },
     "is-string": {
       "version": "1.0.7",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-symbol": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
     },
     "is-typed-array": {
       "version": "1.1.12",
-      "dev": true,
       "requires": {
         "which-typed-array": "^1.1.11"
       }
     },
     "is-weakref": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -11552,10 +13341,14 @@
     },
     "js-yaml": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "jsep": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.8.tgz",
+      "integrity": "sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ=="
     },
     "jsesc": {
       "version": "2.5.2",
@@ -11565,9 +13358,39 @@
       "version": "2.3.1",
       "dev": true
     },
+    "json-schema-migrate": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-0.2.0.tgz",
+      "integrity": "sha512-dq4/oHWmtw/+0ytnXsDqVn+VsVweTEmzm5jLgguPn9BjSzn6/q58ZiZx3BHiQyJs612f0T5Z+MrUEUUY5DHsRg==",
+      "requires": {
+        "ajv": "^5.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw=="
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA=="
+        }
+      }
+    },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true
+      "version": "0.4.1"
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11580,6 +13403,16 @@
     "jsonc-parser": {
       "version": "3.2.0",
       "dev": true
+    },
+    "jsonpath-plus": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA=="
+    },
+    "jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
     },
     "jsx-ast-utils": {
       "version": "3.3.5",
@@ -11621,8 +13454,7 @@
       }
     },
     "leven": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.0"
     },
     "levn": {
       "version": "0.4.1",
@@ -11658,6 +13490,11 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "dev": true
@@ -11692,6 +13529,11 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg=="
     },
     "lodash.upperfirst": {
       "version": "4.3.1",
@@ -11783,7 +13625,6 @@
     },
     "minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11826,6 +13667,35 @@
       "dev": true,
       "peer": true
     },
+    "nimma": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.2.tgz",
+      "integrity": "sha512-V52MLl7BU+tH2Np9tDrIXK8bql3MVUadnMIl/0/oZSGC9keuro0O9UUv9QKp0aMvtN8HRew4G7byY7H4eWsxaQ==",
+      "requires": {
+        "@jsep-plugin/regex": "^1.0.1",
+        "@jsep-plugin/ternary": "^1.0.2",
+        "astring": "^1.8.1",
+        "jsep": "^1.2.0",
+        "jsonpath-plus": "^6.0.1",
+        "lodash.topath": "^4.5.2"
+      },
+      "dependencies": {
+        "jsonpath-plus": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
+          "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
+          "optional": true
+        }
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "dev": true
@@ -11846,16 +13716,13 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.3",
-      "dev": true
+      "version": "1.12.3"
     },
     "object-keys": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "object.assign": {
       "version": "4.1.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -11984,6 +13851,110 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parserv2": {
+      "version": "npm:@asyncapi/parser@2.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
+      "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+      "requires": {
+        "@asyncapi/specs": "^5.1.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      },
+      "dependencies": {
+        "@asyncapi/specs": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+          "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+          "requires": {
+            "@types/json-schema": "^7.0.11"
+          }
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "parserv3": {
+      "version": "npm:@asyncapi/parser@3.0.0-next-major-spec.7",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.7.tgz",
+      "integrity": "sha512-iCVCd66h6NXrIVu7aK5RwGuJ4g1j+qD88xxejUwczbpGbhJkuZUzF5jReWNNAizETJttnAwW0rBKjZF4HVqOiQ==",
+      "requires": {
+        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "dev": true
@@ -12054,6 +14025,11 @@
         }
       }
     },
+    "pony-cause": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-1.1.1.tgz",
+      "integrity": "sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "dev": true
@@ -12096,6 +14072,11 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+    },
     "pure-rand": {
       "version": "6.0.2",
       "dev": true
@@ -12103,6 +14084,41 @@
     "queue-microtask": {
       "version": "1.2.3",
       "dev": true
+    },
+    "ramldt2jsonschema": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ramldt2jsonschema/-/ramldt2jsonschema-1.2.3.tgz",
+      "integrity": "sha512-+wLDAV2NNv9NkfEUOYStaDu/6RYgYXeC1zLtXE+dMU/jDfjpN4iJnBGycDwFTFaIQGosOQhxph7fEX6Mpwxdug==",
+      "requires": {
+        "commander": "^5.0.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^0.2.0",
+        "webapi-parser": "^0.5.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
     },
     "randomatic": {
       "version": "3.1.1",
@@ -12171,7 +14187,6 @@
     },
     "regexp.prototype.flags": {
       "version": "1.5.0",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -12206,6 +14221,11 @@
     "require-directory": {
       "version": "2.1.1",
       "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
       "version": "1.22.4",
@@ -12264,7 +14284,6 @@
     },
     "safe-array-concat": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.0",
@@ -12273,8 +14292,7 @@
       },
       "dependencies": {
         "isarray": {
-          "version": "2.0.5",
-          "dev": true
+          "version": "2.0.5"
         }
       }
     },
@@ -12292,12 +14310,16 @@
     },
     "safe-regex-test": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
         "is-regex": "^1.1.4"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "schema-utils": {
       "version": "3.3.0",
@@ -12337,6 +14359,16 @@
         "randombytes": "^2.1.0"
       }
     },
+    "set-function-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "requires": {
+        "define-data-property": "^1.0.1",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.0"
+      }
+    },
     "set-getter": {
       "version": "0.1.1",
       "dev": true,
@@ -12357,7 +14389,6 @@
     },
     "side-channel": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -12367,6 +14398,14 @@
     "signal-exit": {
       "version": "3.0.7",
       "dev": true
+    },
+    "simple-eval": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.0.tgz",
+      "integrity": "sha512-kpKJR+bqTscgC0xuAl2xHN6bB12lHjC2DCUfqjAx19bQyO3R2EVLOurm3H9AUltv/uFVcSCVNc6faegR+8NYLw==",
+      "requires": {
+        "jsep": "^1.1.2"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -12391,8 +14430,7 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "stack-utils": {
       "version": "2.0.6",
@@ -12432,7 +14470,6 @@
     },
     "string.prototype.trim": {
       "version": "1.2.7",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -12441,7 +14478,6 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.6",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -12450,7 +14486,6 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.6",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -12623,6 +14658,11 @@
       "version": "2.3.6",
       "dev": true
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "ts-api-utils": {
       "version": "1.0.1",
       "dev": true,
@@ -12687,8 +14727,7 @@
       }
     },
     "tslib": {
-      "version": "2.6.1",
-      "dev": true
+      "version": "2.6.1"
     },
     "tsutils": {
       "version": "3.21.0",
@@ -12720,7 +14759,6 @@
     },
     "typed-array-buffer": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1",
@@ -12729,7 +14767,6 @@
     },
     "typed-array-byte-length": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "for-each": "^0.3.3",
@@ -12739,7 +14776,6 @@
     },
     "typed-array-byte-offset": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -12750,7 +14786,6 @@
     },
     "typed-array-length": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "for-each": "^0.3.3",
@@ -12767,7 +14802,6 @@
     },
     "unbox-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -12789,20 +14823,28 @@
     },
     "uri-js": {
       "version": "4.4.1",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.3.0",
-          "dev": true
+          "version": "2.3.0"
         }
       }
+    },
+    "urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",
       "dev": true
+    },
+    "utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -12838,6 +14880,37 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
+    },
+    "webapi-parser": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webapi-parser/-/webapi-parser-0.5.0.tgz",
+      "integrity": "sha512-fPt6XuMqLSvBz8exwX4QE1UT+pROLHa00EMDCdO0ybICduwQ1V4f7AWX4pNOpCp+x+0FjczEsOxtQU0d8L3QKw==",
+      "requires": {
+        "ajv": "6.5.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+        }
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
       "version": "5.88.2",
@@ -12882,6 +14955,15 @@
       "dev": true,
       "peer": true
     },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "dev": true,
@@ -12891,7 +14973,6 @@
     },
     "which-boxed-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -12902,7 +14983,6 @@
     },
     "which-typed-array": {
       "version": "1.1.11",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepublishOnly": "npm run generate:assets"
   },
   "dependencies": {
-    
+    "@smoya/multi-parser": "^4.1.0"
   },
   "devDependencies": {
     "@jest/types": "^29.0.2",

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,9 +1,22 @@
+import { AsyncAPIDocumentInterface } from '@asyncapi/parser';
+
 export enum MetricType {
   Counter = 'counter',
   Gauge = 'gauge'
 }
 
 export type MetricMetadata = { [key: string]: any };
+
+export function MetadataFromDocument(doc: AsyncAPIDocumentInterface, metadata: MetricMetadata = []): MetricMetadata {
+  metadata['_asyncapi_version'] = doc.version();
+  metadata['_asyncapi_servers'] = doc.allServers().all().length;
+  metadata['_asyncapi_channels'] = doc.allChannels().all().length;
+  metadata['_asyncapi_messages'] = doc.allMessages().all().length;
+  metadata['_asyncapi_operations_send'] = doc.allOperations().filterBySend().length;
+  metadata['_asyncapi_operations_receive'] = doc.allOperations().filterByReceive().length;
+  metadata['_asyncapi_schemas'] = doc.allSchemas().all().length;
+  return metadata;
+}
   
 export class Metric {
   name: string;

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -15,14 +15,22 @@ export class Recorder {
   gauge(name: string, value: number, metadata: MetricMetadata = {}) {
     this.record(new Metric(name, MetricType.Gauge, value, metadata));
   }
+  
+  recordValidateActionExecution(metadata: MetricMetadata = {}) {
+    this.recordActionExecution('validate', metadata);
+  }
+
+  recordGenerateActionExecution(metadata: MetricMetadata = {}) {
+    this.recordActionExecution('generate', metadata);
+  }
 
   recordActionExecution(actionName: string, metadata: MetricMetadata = {}) {
-    actionName = `action.executed.${  actionName}`;
-    this.record(new Metric(actionName, MetricType.Counter, 1, metadata));
+    metadata['action'] = actionName;
+    this.record(new Metric('action.executed', MetricType.Counter, 1, metadata));
   }
 
   record(metric: Metric) {
-    metric.name = this.prefix.endsWith('.') ? this.prefix + metric.name : `${this.prefix  }.${  metric.name}`;
+    metric.name = this.prefix.endsWith('.') ? this.prefix + metric.name : `${ this.prefix }.${ metric.name }`;
     this.metrics.push(metric);
   }
 

--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -1,0 +1,32 @@
+import exp from 'constants';
+import { MetadataFromDocument } from '../src/metrics';
+import { NewParser, AsyncAPIDocument } from '@smoya/multi-parser';
+
+describe('Metrics', function() {
+  const parser = NewParser();
+  const doc = { asyncapi: '2.6.0', info: { title: 'test', version: '1.0.0' }, servers: { serverOne: { url: 'localhost', protocol: 'ws' } } ,channels: { '/test': { publish: { message: { payload: { type: 'object' } } } }, '/test_two': { subscribe: { message: { payload: { type: 'object' } } } } } };
+  
+  it('MetadataFromDocument with no previous metadata', async function() {
+    const {document} = await parser.parse(doc);
+    const metadata = MetadataFromDocument(document as AsyncAPIDocument);
+    expect(metadata['_asyncapi_version']).toEqual('2.6.0');
+    expect(metadata['_asyncapi_servers']).toEqual(1);
+    expect(metadata['_asyncapi_channels']).toEqual(2);
+    expect(metadata['_asyncapi_messages']).toEqual(2);
+    expect(metadata['_asyncapi_operations_send']).toEqual(1);
+    expect(metadata['_asyncapi_operations_receive']).toEqual(1);
+    expect(metadata['_asyncapi_schemas']).toEqual(2);
+  });
+  it('MetadataFromDocument with previous metadata', async function() {
+    const {document} = await parser.parse(doc);
+    const metadata = MetadataFromDocument(document as AsyncAPIDocument, { test: true });
+    expect(metadata['test']).toBeTruthy();
+    expect(metadata['_asyncapi_version']).toEqual('2.6.0');
+    expect(metadata['_asyncapi_servers']).toEqual(1);
+    expect(metadata['_asyncapi_channels']).toEqual(2);
+    expect(metadata['_asyncapi_messages']).toEqual(2);
+    expect(metadata['_asyncapi_operations_send']).toEqual(1);
+    expect(metadata['_asyncapi_operations_receive']).toEqual(1);
+    expect(metadata['_asyncapi_schemas']).toEqual(2);
+  });
+});

--- a/test/recorder.spec.ts
+++ b/test/recorder.spec.ts
@@ -54,7 +54,7 @@ describe('Recorder', function() {
   it('recordActionExecution()', async function() {
     const recorderMetricsSpy = [];
     const recorder = new Recorder('test', new testSink(), recorderMetricsSpy);
-    const expectedMetric = new Metric('test.action.executed.validate', MetricType.Counter, 1, { success: true });
+    const expectedMetric = new Metric('test.action.executed', MetricType.Counter, 1, { action: 'validate', success: true });
     
     recorder.recordActionExecution('validate', { success: true });
     expect(recorderMetricsSpy).toHaveLength(1);
@@ -65,7 +65,7 @@ describe('Recorder', function() {
     const sink = new testSink();
     const recorderMetricsSpy = [];
     const {recorder, stop} = WithPeriodicFlushRecorder(new Recorder('test', sink, recorderMetricsSpy), 100);
-    const expectedMetric = new Metric('test.action.executed.validate', MetricType.Counter, 1, { success: true });
+    const expectedMetric = new Metric('test.action.executed', MetricType.Counter, 1, { action: 'validate', success: true });
     
     recorder.recordActionExecution('validate', { success: true });
     expect(recorderMetricsSpy).toHaveLength(1);


### PR DESCRIPTION
**Description**

This PR adds a new method that creates a new Metadata object based on an AsyncAPI document. It decorates it with: 

- AsyncAPI document version
- Num of servers
- Num of channels
- Num of messages
- Num of send operations 
- Num of receive operations 
- Num of schemas

It additionally adds two new shortcuts called `recordGenerateActionExecution` and `recordValidateActionExecution`.