### PR TITLE
test: replace `.toBe` matchers at recorder tests

### DIFF
--- a/test/recorder.spec.ts
+++ b/test/recorder.spec.ts
@@ -22,13 +22,13 @@ describe('Recorder', function() {
 
     await recorder.record(metric);
     expect(recorderMetricsSpy).toHaveLength(1);
-    expect(recorderMetricsSpy[0]).toBe(metric);
+    expect(recorderMetricsSpy[0]).toEqual(metric);
     expect(sink.metrics).toHaveLength(0);
 
     await recorder.flush();
     expect(recorderMetricsSpy).toHaveLength(0);
     expect(sink.metrics).toHaveLength(1);
-    expect(sink.metrics[0]).toBe(metric);
+    expect(sink.metrics[0]).toEqual(metric);
   });
 
   it('count()', async function() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

Just replacing `.toBe` jest matchers by `.toEqual` ones as we talked about.
cc @smoya 