### PR TITLE
fix: ensure MetricMetadata is always an object + remove underscored from fields

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -5,16 +5,16 @@ export enum MetricType {
   Gauge = 'gauge'
 }
 
-export type MetricMetadata = { [key: string]: any };
+export type MetricMetadata = Record<string, unknown>
 
-export function MetadataFromDocument(doc: AsyncAPIDocument, metadata: MetricMetadata = []): MetricMetadata {
-  metadata['_asyncapi_version'] = doc.version();
-  metadata['_asyncapi_servers'] = doc.allServers().all().length;
-  metadata['_asyncapi_channels'] = doc.allChannels().all().length;
-  metadata['_asyncapi_messages'] = doc.allMessages().all().length;
-  metadata['_asyncapi_operations_send'] = doc.allOperations().filterBySend().length;
-  metadata['_asyncapi_operations_receive'] = doc.allOperations().filterByReceive().length;
-  metadata['_asyncapi_schemas'] = doc.allSchemas().all().length;
+export function MetadataFromDocument(doc: AsyncAPIDocument, metadata: MetricMetadata = {}): MetricMetadata {
+  metadata['asyncapi_version'] = doc.version();
+  metadata['asyncapi_servers'] = doc.allServers().all().length;
+  metadata['asyncapi_channels'] = doc.allChannels().all().length;
+  metadata['asyncapi_messages'] = doc.allMessages().all().length;
+  metadata['asyncapi_operations_send'] = doc.allOperations().filterBySend().length;
+  metadata['asyncapi_operations_receive'] = doc.allOperations().filterByReceive().length;
+  metadata['asyncapi_schemas'] = doc.allSchemas().all().length;
   return metadata;
 }
   

--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -8,24 +8,24 @@ describe('Metrics', function() {
   it('MetadataFromDocument with no previous metadata', async function() {
     const {document} = await parser.parse(doc);
     const metadata = MetadataFromDocument(document as AsyncAPIDocument);
-    expect(metadata['_asyncapi_version']).toEqual('2.6.0');
-    expect(metadata['_asyncapi_servers']).toEqual(1);
-    expect(metadata['_asyncapi_channels']).toEqual(2);
-    expect(metadata['_asyncapi_messages']).toEqual(2);
-    expect(metadata['_asyncapi_operations_send']).toEqual(1);
-    expect(metadata['_asyncapi_operations_receive']).toEqual(1);
-    expect(metadata['_asyncapi_schemas']).toEqual(2);
+    expect(metadata['asyncapi_version']).toEqual('2.6.0');
+    expect(metadata['asyncapi_servers']).toEqual(1);
+    expect(metadata['asyncapi_channels']).toEqual(2);
+    expect(metadata['asyncapi_messages']).toEqual(2);
+    expect(metadata['asyncapi_operations_send']).toEqual(1);
+    expect(metadata['asyncapi_operations_receive']).toEqual(1);
+    expect(metadata['asyncapi_schemas']).toEqual(2);
   });
   it('MetadataFromDocument with previous metadata', async function() {
     const {document} = await parser.parse(doc);
     const metadata = MetadataFromDocument(document as AsyncAPIDocument, { test: true });
     expect(metadata['test']).toBeTruthy();
-    expect(metadata['_asyncapi_version']).toEqual('2.6.0');
-    expect(metadata['_asyncapi_servers']).toEqual(1);
-    expect(metadata['_asyncapi_channels']).toEqual(2);
-    expect(metadata['_asyncapi_messages']).toEqual(2);
-    expect(metadata['_asyncapi_operations_send']).toEqual(1);
-    expect(metadata['_asyncapi_operations_receive']).toEqual(1);
-    expect(metadata['_asyncapi_schemas']).toEqual(2);
+    expect(metadata['asyncapi_version']).toEqual('2.6.0');
+    expect(metadata['asyncapi_servers']).toEqual(1);
+    expect(metadata['asyncapi_channels']).toEqual(2);
+    expect(metadata['asyncapi_messages']).toEqual(2);
+    expect(metadata['asyncapi_operations_send']).toEqual(1);
+    expect(metadata['asyncapi_operations_receive']).toEqual(1);
+    expect(metadata['asyncapi_schemas']).toEqual(2);
   });
 });


### PR DESCRIPTION
**Description**

This PR fixes the type for `MetricMetadata` in order to ensure it is always an object, so no more arrays are allowed. We were wrongly creating an empty array by default and that is not accepted by NewRelic.
This PR also removes the `_` (underscore) prefix from generated metadata fields because same reason.


cc @peter-rr 