### PR TITLE
feat!: add method for 'action.invoked' new metric to be implemented

### DIFF
--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -16,11 +16,11 @@ export class Recorder {
     this.record(new Metric(name, MetricType.Gauge, value, metadata));
   }
   
-  async recordActionExecution(actionName: string, metadata: MetricMetadata = {}) {
+  async recordActionExecuted(actionName: string, metadata: MetricMetadata = {}) {
     metadata['action'] = actionName;
     this.record(new Metric('action.executed', MetricType.Counter, 1, metadata));
   }
-  async recordActionInvoke(actionName: string, metadata: MetricMetadata = {}) {
+  async recordActionInvoked(actionName: string, metadata: MetricMetadata = {}) {
     metadata['action'] = actionName;
     this.record(new Metric('action.invoked', MetricType.Counter, 1, metadata));
   }

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -20,6 +20,10 @@ export class Recorder {
     metadata['action'] = actionName;
     this.record(new Metric('action.executed', MetricType.Counter, 1, metadata));
   }
+  async recordActionInvoke(actionName: string, metadata: MetricMetadata = {}) {
+    metadata['action'] = actionName;
+    this.record(new Metric('action.invoked', MetricType.Counter, 1, metadata));
+  }
 
   async record(metric: Metric) {
     metric.name = this.prefix.endsWith('.') ? this.prefix + metric.name : `${ this.prefix }.${ metric.name }`;

--- a/test/recorder.spec.ts
+++ b/test/recorder.spec.ts
@@ -51,22 +51,22 @@ describe('Recorder', function() {
     expect(recorderMetricsSpy[0]).toEqual(expectedMetric);
   });
 
-  it('recordActionExecution()', async function() {
+  it('recordActionExecuted()', async function() {
     const recorderMetricsSpy = [];
     const recorder = new Recorder('test', new testSink(), recorderMetricsSpy);
     const expectedMetric = new Metric('test.action.executed', MetricType.Counter, 1, { action: 'validate', success: true });
     
-    await recorder.recordActionExecution('validate', { success: true });
+    await recorder.recordActionExecuted('validate', { success: true });
     expect(recorderMetricsSpy).toHaveLength(1);
     expect(recorderMetricsSpy[0]).toEqual(expectedMetric);
   });
   
-  it('recordActionInvoke()', async function() {
+  it('recordActionInvoked()', async function() {
     const recorderMetricsSpy = [];
     const recorder = new Recorder('test', new testSink(), recorderMetricsSpy);
-    const expectedMetric = new Metric('test.action.invoked', MetricType.Counter, 1, { action: 'convert', success: true });
+    const expectedMetric = new Metric('test.action.invoked', MetricType.Counter, 1, { action: 'convert' });
     
-    await recorder.recordActionInvoke('convert', { success: true });
+    await recorder.recordActionInvoked('convert');
     expect(recorderMetricsSpy).toHaveLength(1);
     expect(recorderMetricsSpy[0]).toEqual(expectedMetric);
   });
@@ -78,7 +78,7 @@ describe('Recorder', function() {
     const {recorder, stop} = WithPeriodicFlushRecorder(new Recorder('test', sink, recorderMetricsSpy), 100);
     const expectedMetric = new Metric('test.action.executed', MetricType.Counter, 1, { action: 'validate', success: true });
     
-    await recorder.recordActionExecution('validate', { success: true });
+    await recorder.recordActionExecuted('validate', { success: true });
     expect(recorderMetricsSpy).toHaveLength(1);
     expect(recorderMetricsSpy[0]).toEqual(expectedMetric);
 

--- a/test/recorder.spec.ts
+++ b/test/recorder.spec.ts
@@ -60,6 +60,16 @@ describe('Recorder', function() {
     expect(recorderMetricsSpy).toHaveLength(1);
     expect(recorderMetricsSpy[0]).toEqual(expectedMetric);
   });
+  
+  it('recordActionInvoke()', async function() {
+    const recorderMetricsSpy = [];
+    const recorder = new Recorder('test', new testSink(), recorderMetricsSpy);
+    const expectedMetric = new Metric('test.action.invoked', MetricType.Counter, 1, { action: 'convert', success: true });
+    
+    await recorder.recordActionInvoke('convert', { success: true });
+    expect(recorderMetricsSpy).toHaveLength(1);
+    expect(recorderMetricsSpy[0]).toEqual(expectedMetric);
+  });
 
   it('WithPeriodicFlushRecorder()', async function() {
     jest.useFakeTimers(); // this mocks setTimeout global function


### PR DESCRIPTION
Just adding `recordActionInvoke()` method and its corresponding test.

This method will be called by the different CLI commands at the time they are invoked in order to send a new metric called `asyncapi_adoption.action.invoked`.

Relates to:
https://github.com/asyncapi/cli/issues/841