### PR TITLE
feat: set timeout to newrelic's request

### DIFF
--- a/test/sinks/newrelic.spec.ts
+++ b/test/sinks/newrelic.spec.ts
@@ -27,7 +27,8 @@ describe('Recorder', function() {
         'Content-Type': 'application/json', 
         'X-License-Key': 'FAKE_LICENSE_KEY'
       },
-      method: 'POST'
+      method: 'POST',
+      signal: new AbortController().signal
     };
 
     await sink.send(metrics);


### PR DESCRIPTION
**Description**

This PR adds the feature of setting a timeout (in ms) to terminate the request made to New Relic servers. By default 2000ms.

**Related issue(s)**
Fixes https://github.com/smoya/asyncapi-adoption-metrics/issues/18

cc @peter-rr 