### PR TITLE
chore: rename one of the metrics

### DIFF
--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -16,9 +16,9 @@ export class Recorder {
     this.record(new Metric(name, MetricType.Gauge, value, metadata));
   }
   
-  async recordActionExecuted(actionName: string, metadata: MetricMetadata = {}) {
+  async recordActionFinished(actionName: string, metadata: MetricMetadata = {}) {
     metadata['action'] = actionName;
-    this.record(new Metric('action.executed', MetricType.Counter, 1, metadata));
+    this.record(new Metric('action.finished', MetricType.Counter, 1, metadata));
   }
   async recordActionInvoked(actionName: string, metadata: MetricMetadata = {}) {
     metadata['action'] = actionName;

--- a/test/recorder.spec.ts
+++ b/test/recorder.spec.ts
@@ -51,12 +51,12 @@ describe('Recorder', function() {
     expect(recorderMetricsSpy[0]).toEqual(expectedMetric);
   });
 
-  it('recordActionExecuted()', async function() {
+  it('recordActionFinished()', async function() {
     const recorderMetricsSpy = [];
     const recorder = new Recorder('test', new testSink(), recorderMetricsSpy);
-    const expectedMetric = new Metric('test.action.executed', MetricType.Counter, 1, { action: 'validate', success: true });
+    const expectedMetric = new Metric('test.action.finished', MetricType.Counter, 1, { action: 'validate', success: true });
     
-    await recorder.recordActionExecuted('validate', { success: true });
+    await recorder.recordActionFinished('validate', { success: true });
     expect(recorderMetricsSpy).toHaveLength(1);
     expect(recorderMetricsSpy[0]).toEqual(expectedMetric);
   });
@@ -76,9 +76,9 @@ describe('Recorder', function() {
     const sink = new testSink();
     const recorderMetricsSpy = [];
     const {recorder, stop} = WithPeriodicFlushRecorder(new Recorder('test', sink, recorderMetricsSpy), 100);
-    const expectedMetric = new Metric('test.action.executed', MetricType.Counter, 1, { action: 'validate', success: true });
+    const expectedMetric = new Metric('test.action.finished', MetricType.Counter, 1, { action: 'validate', success: true });
     
-    await recorder.recordActionExecuted('validate', { success: true });
+    await recorder.recordActionFinished('validate', { success: true });
     expect(recorderMetricsSpy).toHaveLength(1);
     expect(recorderMetricsSpy[0]).toEqual(expectedMetric);
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
The metric `action.executed` will be named `action.finished` from now on. All the methods and variables related need to be changed as well.

cc @smoya 