### PR TITLE
fix: update @smoya/multi-parser to 5.0.6 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smoya/multi-parser": "^5.0.5"
+        "@smoya/multi-parser": "^5.0.6"
       },
       "devDependencies": {
         "@jest/types": "^29.0.2",
@@ -1615,9 +1615,9 @@
       }
     },
     "node_modules/@smoya/multi-parser": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-5.0.5.tgz",
-      "integrity": "sha512-xslTCMvNl5maGphjU6cWXsDKS7PZH+7yyAiuv4F2XBUOm4s3IcKfRIqnGAGgEgYm5fb/oZzq5Rv2kZMETyniuA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-5.0.6.tgz",
+      "integrity": "sha512-o1pzaOTUzNWk7QIWA8ArrNCaZqAB85SZRcOJ+hKTT3YYM1ETSliufMm6N4e7NCWAbVRDUOqK0yuCVMIG0OSTxw==",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.3",
         "@asyncapi/openapi-schema-parser": "^3.0.4",
@@ -1625,7 +1625,7 @@
         "@asyncapi/raml-dt-schema-parser": "^4.0.4",
         "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
         "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8",
-        "parserapiv3": "npm:@asyncapi/parser@^3.0.12"
+        "parserapiv3": "npm:@asyncapi/parser@^3.0.13"
       }
     },
     "node_modules/@stoplight/json": {
@@ -7329,11 +7329,11 @@
     },
     "node_modules/parserapiv3": {
       "name": "@asyncapi/parser",
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.12.tgz",
-      "integrity": "sha512-F46FSg6XZDy8LSE0U8MnK0JsvRdDXN2XwE/prewr6d+JE1DNR7fwYAFty7SNh2Ym04D5G+YHZEm2QbbzOsrbsQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.13.tgz",
+      "integrity": "sha512-ULNVAsfdLJJJeBDCAWGfleEzmkKJCWcZaYzhTIrqccJa6yZvWrMPLGMYhJhBkdczDxjtdi0iqMmxEy2GC36mUA==",
       "dependencies": {
-        "@asyncapi/specs": "^6.5.5",
+        "@asyncapi/specs": "^6.5.6",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "^3.20.2",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -7355,9 +7355,9 @@
       }
     },
     "node_modules/parserapiv3/node_modules/@asyncapi/specs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.5.tgz",
-      "integrity": "sha512-5uPO22ZsLjh6ZdSHF/wROogOaA3BlYUOQqBf5+hdBbXXj/jIHJWHTYSLWCvws7DQM0++tHslFZ+xWbURTc927w==",
+      "version": "6.5.6",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.5.6.tgz",
+      "integrity": "sha512-TI3OIY0UFf7wPyjV9GjKqL6C4YJ0xOJ7wX33sxVqCf0XXIq4otGHa1XiBcCUAgdbMlO7b8jsFRxuUsVXCsYDVQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepublishOnly": "npm run generate:assets"
   },
   "dependencies": {
-    "@smoya/multi-parser": "^5.0.5"
+    "@smoya/multi-parser": "^5.0.6"
   },
   "devDependencies": {
     "@jest/types": "^29.0.2",


### PR DESCRIPTION
This PR will update @smoya/multi-parser dependency to the latest version.

cc @smoya 